### PR TITLE
Coffeelint support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ script:
 after_script:
 - npm run-script coverage
 notifications:
+  email: false
   slack:
     secure: FmFl6zbzPSY5eqs/IRJtVMkx6e87xXHpTyqrekHgr8fP6jS1KjHVkMOw5kUs7Q5NHJuvBUoLUZkRT4hgzMK7r/jaqOROrjIAF8PfYFBnt8IVAKAz3mco310KJ5pHEqNg4EWGbWj8p4d0vQ1DQCggZXILx2lMReISHuPldaXzUu0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '0.10'
 after_script:
 - npm run-script coverage
+- find -path ./node_modules -prune -o -name "*.coffee" -exec $(npm bin)/coffeelint "{}" +
 notifications:
   slack:
     secure: FmFl6zbzPSY5eqs/IRJtVMkx6e87xXHpTyqrekHgr8fP6jS1KjHVkMOw5kUs7Q5NHJuvBUoLUZkRT4hgzMK7r/jaqOROrjIAF8PfYFBnt8IVAKAz3mco310KJ5pHEqNg4EWGbWj8p4d0vQ1DQCggZXILx2lMReISHuPldaXzUu0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
 - '0.10'
+script:
+- find -path ./node_modules -prune -o -name "*.coffee" -exec $(npm bin)/coffeelint "{}" +
 after_script:
 - npm run-script coverage
-- find -path ./node_modules -prune -o -name "*.coffee" -exec $(npm bin)/coffeelint "{}" +
 notifications:
   slack:
     secure: FmFl6zbzPSY5eqs/IRJtVMkx6e87xXHpTyqrekHgr8fP6jS1KjHVkMOw5kUs7Q5NHJuvBUoLUZkRT4hgzMK7r/jaqOROrjIAF8PfYFBnt8IVAKAz3mco310KJ5pHEqNg4EWGbWj8p4d0vQ1DQCggZXILx2lMReISHuPldaXzUu0=

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ teascript
 =========
 [![Build
 Status](https://travis-ci.org/alexschneider/teascript.svg?branch=as%2Ftravis)](https://travis-ci.org/alexschneider/teascript)
-[![Coverage Status](https://coveralls.io/repos/alexschneider/teascript/badge.svg)](https://coveralls.io/r/alexschneider/teascript)
+[![Coverage
+Status](https://coveralls.io/repos/alexschneider/teascript/badge.svg?branch=scanner-tests)](https://coveralls.io/r/alexschneider/teascript?branch=scanner-tests)
 
 Check out our wiki: https://github.com/alexschneider/teascript/wiki/1)-Ideas-for-Language

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ teascript
 =========
 [![Build
 Status](https://travis-ci.org/alexschneider/teascript.svg?branch=as%2Ftravis)](https://travis-ci.org/alexschneider/teascript)
-[![Coverage
-Status](https://coveralls.io/repos/alexschneider/teascript/badge.svg?branch=as%2Fcoverage)](https://coveralls.io/r/alexschneider/teascript?branch=as%2Fcoverage)
+[![Coverage Status](https://coveralls.io/repos/alexschneider/teascript/badge.svg)](https://coveralls.io/r/alexschneider/teascript)
+
 
 Check out our wiki: https://github.com/alexschneider/teascript/wiki/1)-Ideas-for-Language

--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ teascript
 Status](https://travis-ci.org/alexschneider/teascript.svg?branch=as%2Ftravis)](https://travis-ci.org/alexschneider/teascript)
 [![Coverage Status](https://coveralls.io/repos/alexschneider/teascript/badge.svg)](https://coveralls.io/r/alexschneider/teascript)
 
-
 Check out our wiki: https://github.com/alexschneider/teascript/wiki/1)-Ideas-for-Language

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,116 @@
+{
+    "arrow_spacing": {
+        "level": "error"
+    },
+    "camel_case_classes": {
+        "level": "error"
+    },
+    "coffeescript_error": {
+        "level": "error"
+    },
+    "colon_assignment_spacing": {
+        "level": "ignore",
+        "spacing": {
+            "left": 0,
+            "right": 0
+        }
+    },
+    "cyclomatic_complexity": {
+        "value": 10,
+        "level": "ignore"
+    },
+    "duplicate_key": {
+        "level": "error"
+    },
+    "empty_constructor_needs_parens": {
+        "level": "error"
+    },
+    "ensure_comprehensions": {
+        "level": "error"
+    },
+    "indentation": {
+        "value": 2,
+        "level": "error"
+    },
+    "line_endings": {
+        "level": "ignore",
+        "value": "unix"
+    },
+    "max_line_length": {
+        "value": 80,
+        "level": "error",
+        "limitComments": true
+    },
+    "missing_fat_arrows": {
+        "level": "ignore"
+    },
+    "newlines_after_classes": {
+        "value": 3,
+        "level": "ignore"
+    },
+    "no_backticks": {
+        "level": "error"
+    },
+    "no_debugger": {
+        "level": "warn"
+    },
+    "no_empty_functions": {
+        "level": "ignore"
+    },
+    "no_empty_param_list": {
+        "level": "ignore"
+    },
+    "no_implicit_braces": {
+        "level": "error",
+        "strict": true
+    },
+    "no_implicit_parens": {
+        "strict": true,
+        "level": "error"
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "ignore"
+    },
+    "no_plusplus": {
+        "level": "ignore"
+    },
+    "no_stand_alone_at": {
+        "level": "ignore"
+    },
+    "no_tabs": {
+        "level": "error"
+    },
+    "no_throwing_strings": {
+        "level": "error"
+    },
+    "no_trailing_semicolons": {
+        "level": "error"
+    },
+    "no_trailing_whitespace": {
+        "level": "error",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "warn"
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "non_empty_constructor_needs_parens": {
+        "level": "error"
+    },
+    "prefer_english_operator": {
+        "level": "error",
+        "doubleNotLevel": "ignore"
+    },
+    "space_operators": {
+        "level": "error"
+    },
+    "spacing_after_comma": {
+        "level": "error"
+    },
+    "transform_messes_up_line_numbers": {
+        "level": "warn"
+    }
+}

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -23,7 +23,7 @@
         "level": "error"
     },
     "empty_constructor_needs_parens": {
-        "level": "error"
+        "level": "ignore"
     },
     "ensure_comprehensions": {
         "level": "error"
@@ -33,7 +33,7 @@
         "level": "error"
     },
     "line_endings": {
-        "level": "ignore",
+        "level": "error",
         "value": "unix"
     },
     "max_line_length": {
@@ -61,12 +61,12 @@
         "level": "ignore"
     },
     "no_implicit_braces": {
-        "level": "error",
+        "level": "ignore",
         "strict": true
     },
     "no_implicit_parens": {
         "strict": true,
-        "level": "error"
+        "level": "ignore"
     },
     "no_interpolation_in_single_quotes": {
         "level": "ignore"
@@ -98,7 +98,7 @@
         "level": "warn"
     },
     "non_empty_constructor_needs_parens": {
-        "level": "error"
+        "level": "ignore"
     },
     "prefer_english_operator": {
         "level": "error",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "chai": "latest",
+    "coffeelint": "^1.8.1",
     "coveralls": "^2.11.2",
     "ibrik": "^2.0.0",
     "mocha": "latest",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "chai": "latest",
+    "coffee-coverage": "^0.4.4",
     "coffeelint": "^1.8.1",
     "coveralls": "^2.11.2",
-    "ibrik": "^2.0.0",
     "mocha": "latest",
     "mocha-lcov-reporter": "0.0.1",
     "sinon": "latest",
@@ -19,6 +19,6 @@
   },
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register ./test/*spec.coffee",
-    "coverage": "ibrik cover ./node_modules/mocha/bin/_mocha --report lcovonly --compilers coffee:coffee-script/register ./test/*spec.coffee && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "coverage": "mocha --require coffee-coverage/register --compilers coffee:coffee-script/register test --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
   }
 }

--- a/scanner.coffee
+++ b/scanner.coffee
@@ -1,29 +1,35 @@
-LineByLineReader = require 'line-by-line'
-LineScanner = require './tools/line_scanner'
+LineByLineReader = require('line-by-line')
+LineScanner = require('./tools/line_scanner')
 
 module.exports = (filePath, callback) ->
-  reader = new LineByLineReader filePath, {encoding: 'utf8'}
+  reader = new LineByLineReader(filePath, {encoding: 'utf8'})
   allTokens = []
-  currentScannerState = 
-    multiline:
+  currentScannerState = {
+    multiline: {
       comment: false
       string: false
+    }
+  }
+
   lineNumber = 0
   
-  reader.on 'error', (error) ->
-    # TODO handle error stuff 
+  reader.on('error', (error) ->
+    # TODO handle error stuff
+  )
 
-  reader.on 'line', (line) ->
+  reader.on('line', (line) ->
     lineNumber++
-    lineScanner = new LineScanner line, currentScannerState
+    lineScanner = new LineScanner(line, currentScannerState)
     {errors, lineTokens, currentState} = lineScanner.scan()
-    return callback CustomErrorHandler(errors, lineNumber) if errors
+    return callback(CustomErrorHandler(errors, lineNumber)) if errors
     # add the tokens of the line to all the tokens
-    allTokens.push lineTokens
+    allTokens.push(lineTokens)
     # update the current state of the scanner
     currentScannerState = currentState
+  )
 
-  reader.once 'end', ->
-    console.log JSON.stringify(tokens)
-    # push some kind of an EOF token here? 
-    callback tokens
+  reader.once('end', ->
+    console.log(JSON.stringify(tokens))
+    # push some kind of an EOF token here?
+    callback(tokens)
+  )

--- a/scanner.coffee
+++ b/scanner.coffee
@@ -1,35 +1,29 @@
-LineByLineReader = require('line-by-line')
-LineScanner = require('./tools/line_scanner')
+LineByLineReader = require 'line-by-line'
+LineScanner = require './tools/line_scanner'
 
 module.exports = (filePath, callback) ->
-  reader = new LineByLineReader(filePath, {encoding: 'utf8'})
+  reader = new LineByLineReader filePath, {encoding: 'utf8'}
   allTokens = []
-  currentScannerState = {
-    multiline: {
+  currentScannerState =
+    multiline:
       comment: false
       string: false
-    }
-  }
-
   lineNumber = 0
   
-  reader.on('error', (error) ->
+  reader.on 'error', (error) ->
     # TODO handle error stuff
-  )
 
-  reader.on('line', (line) ->
+  reader.on 'line', (line) ->
     lineNumber++
-    lineScanner = new LineScanner(line, currentScannerState)
+    lineScanner = new LineScanner line, currentScannerState
     {errors, lineTokens, currentState} = lineScanner.scan()
-    return callback(CustomErrorHandler(errors, lineNumber)) if errors
+    return callback CustomErrorHandler(errors, lineNumber) if errors
     # add the tokens of the line to all the tokens
-    allTokens.push(lineTokens)
+    allTokens.push lineTokens
     # update the current state of the scanner
     currentScannerState = currentState
-  )
 
-  reader.once('end', ->
-    console.log(JSON.stringify(tokens))
+  reader.once 'end', ->
+    console.log JSON.stringify(tokens)
     # push some kind of an EOF token here?
-    callback(tokens)
-  )
+    callback tokens

--- a/test/line_scanner_spec.coffee
+++ b/test/line_scanner_spec.coffee
@@ -1,20 +1,20 @@
-sinon = require 'sinon'
-chai = require 'chai'
-sinonChai = require 'sinon-chai'
+sinon = require('sinon')
+chai = require('chai')
+sinonChai = require('sinon-chai')
 expect = chai.expect
 chai.use(sinonChai)
-LineScanner = require '../tools/line_scanner'
+LineScanner = require('../tools/line_scanner')
 
 
-describe 'LineScanner', ->
+describe('LineScanner', ->
 
-  describe '#scan', ->
-    context 'when the line has valid teascript tokens', ->
-      lineScanner = new LineScanner "f :=  -> 'hello' a.move() bool # comment"
+  describe('#scan', ->
+    context('when the line has valid teascript tokens', ->
+      lineScanner = new LineScanner("f :=  -> 'hello' a.move() bool # comment")
       {lineTokens} = lineScanner.scan()
 
-      it 'returns the appropriate tokens', ->
-        expect(lineTokens).to.eql [
+      it('returns the appropriate tokens', ->
+        expect(lineTokens).to.eql([
           {kind: 'ID', lexeme: 'f', start: 0},
           {kind: ':=', lexeme: ':=', start: 2},
           {kind: '->', lexeme: '->', start: 6},
@@ -26,308 +26,430 @@ describe 'LineScanner', ->
           {kind: ')', lexeme: ')', start: 24},
           {kind: 'bool', lexeme: 'bool', start: 26},
           {kind: 'newline', lexeme: 'newline', start: 27}
-        ]
+        ])
+      )
+    )
 
-    context 'when the line is empty', ->
-      lineScanner = new LineScanner ""
+    context('when the line is empty', ->
+      lineScanner = new LineScanner('')
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it 'returns without trying to extract any tokens', ->
+      it('returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
+      )
+    )
 
-    context 'when the line is full of spaces', ->
-      lineScanner = new LineScanner "                    "
+    context('when the line is full of spaces', ->
+      lineScanner = new LineScanner('                    ')
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it 'returns without trying to extract any tokens', ->
+      it('returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
+      )
+    )
 
-    context 'when the line is commented out', ->
-      lineScanner = new LineScanner "# example commented out line"
+    context('when the line is commented out', ->
+      lineScanner = new LineScanner('# example commented out line')
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it 'returns without trying to extract any tokens', ->
+      it('returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
+      )
+    )
+  )
 
+  describe('#skipSpaces', ->
 
-
-
-  describe '#skipSpaces', ->
-
-    context 'when spaces are the next characters', ->
-      lineScanner = new LineScanner "        x := 5"
+    context('when spaces are the next characters', ->
+      lineScanner = new LineScanner('        x := 5')
       lineScanner.skipSpaces()
 
-      it 'increments the scanner position to the first non-space character', ->
-        expect(lineScanner.position).to.equal 8
+      it('increments the scanner position to the first non-space character', ->
+        expect(lineScanner.position).to.equal(8)
+      )
+    )
 
-    context 'when spaces are not the next characters', ->
-      lineScanner = new LineScanner "x := 5"
+    context('when spaces are not the next characters', ->
+      lineScanner = new LineScanner('x := 5')
       lineScanner.skipSpaces()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
+    )
+  )
 
 
-  describe '#skipComments', ->
+  describe('#skipComments', ->
 
-    context 'when there is a single line comment (single hash symbol)', ->
-      lineScanner = new LineScanner "# this is a single line comment "
+    context('when there is a single line comment (single hash symbol)', ->
+      lineScanner = new LineScanner('# this is a single line comment ')
       lineScanner.skipComments()
 
-      it 'increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal 32
+      it('increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal(32)
+      )
+    )
 
-    context 'when there is a multiline comment without a defined ending', ->
-      lineScanner = new LineScanner "## this is a multiline comment without a defined ending"
+    context('when there is a multiline comment without a defined ending', ->
+      lineScanner = new LineScanner('## this is a multiline comment without a
+                                     defined ending')
       lineScanner.skipComments()
 
-      it 'sets the current state of the mulitline comment of the scanner to be true', ->
+      it('sets the current state of the mulitline comment of the scanner to be
+          true', ->
         expect(lineScanner.currentState.multiline.comment).to.be.true
+      )
 
-      it 'increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal 55
+      it('increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal(55)
+      )
+    )
 
-    context 'when the scanner is in the middle of a multiline comment', ->
-      currentScannerState = multiline: comment: true
-      lineScanner = new LineScanner "this is the continuation of a multiline comment begun elsewhere ##"
-                                    , currentScannerState
+    context('when the scanner is in the middle of a multiline comment', ->
+      currentScannerState = {multiline: {comment: true}}
+      lineScanner = new LineScanner('this is the continuation of a multiline
+                                     comment begun elsewhere ##',
+                                    currentScannerState)
       lineScanner.skipComments()
 
-      it 'toggles the current state of the multiline comment of the scanner back to false', ->
+      it('toggles the current state of the multiline comment of the scanner
+          back to false', ->
         expect(lineScanner.currentState.multiline.comment).to.be.false
+      )
 
-      it 'increments the scanner position to just after the comment', ->
-        expect(lineScanner.position).to.equal 66
+      it('increments the scanner position to just after the comment', ->
+        expect(lineScanner.position).to.equal(66)
+      )
+    )
 
-    context 'when there is a multiline comment with a defined ending', ->
-      lineScanner = new LineScanner "## this is a multiline comment with a defined ending ## f := 5"
+    context('when there is a multiline comment with a defined ending', ->
+      lineScanner = new LineScanner('## this is a multiline comment with a
+                                     defined ending ## f := 5')
       lineScanner.skipComments()
-      
-      it 'toggles the current state of the multiline comment of the scanner back to false', ->
+
+      it('toggles the current state of the multiline comment of the scanner
+          back to false', ->
         expect(lineScanner.currentState.multiline.comment).to.be.false
+      )
 
-      it 'increments the scanner position to just after the comment', ->
-        expect(lineScanner.position).to.equal 55
-    
+      it('increments the scanner position to just after the comment', ->
+        expect(lineScanner.position).to.equal(55)
+      )
+    )
 
-    context 'when a line does not being with a hash symbol (#)', ->
-      lineScanner = new LineScanner "x := 5"
+
+    context('when a line does not being with a hash symbol (#)', ->
+      lineScanner = new LineScanner('x := 5')
       lineScanner.skipComments()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
+    )
+  )
 
-  describe '#extractStringLiterals', ->
+  describe('#extractStringLiterals', ->
 
-    context 'when the next token is a string without a defined ending', ->
-      lineScanner = new LineScanner "'this is a multiline string without a defined ending"
+    context('when the next token is a string without a defined ending', ->
+      lineScanner = new LineScanner("'this is a multiline string without a
+                                     defined ending")
       lineScanner.extractStringLiterals()
 
-      it 'sets the current state of the mulitline string of the scanner to be true', ->
+      it('sets the current state of the mulitline string of the scanner to be
+          true', ->
         expect(lineScanner.currentState.multiline.string).to.be.true
+      )
 
-      it 'increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal 52
+      it('increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal(52)
+      )
 
-      it 'does not add any tokens yet to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql []
+      it('does not add any tokens yet to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([])
+      )
+    )
 
-    context 'when the scanner is in the middle of a multiline string', ->
-      currentScannerState = multiline: string: true
-      lineScanner = new LineScanner "this is the continuation of a multiline string begun elsewhere '"
-                                    , currentScannerState
+    context('when the scanner is in the middle of a multiline string', ->
+      currentScannerState = { multiline: { string: true }}
+      lineScanner = new LineScanner("this is the continuation of a multiline
+                                     string begun elsewhere '",
+                                    currentScannerState)
       lineScanner.extractStringLiterals()
 
-      it 'toggles the current state of the multiline string of the scanner back to false', ->
+      it('toggles the current state of the multiline string of the scanner back
+          to false', ->
         expect(lineScanner.currentState.multiline.string).to.be.false
+      )
 
-      it 'increments the scanner position to the end of the string', ->
-        expect(lineScanner.position).to.equal 64
+      it('increments the scanner position to the end of the string', ->
+        expect(lineScanner.position).to.equal(64)
+      )
 
-      it 'adds the string token to the line tokens', ->
+      it('adds the string token to the line tokens', ->
         expect(lineScanner.lineTokens).to
-          .eql [{
+          .eql([{
             start: 0,
             kind: 'STRLIT',
-            lexeme: "this is the continuation of a multiline string begun elsewhere '"
-          }]
+            lexeme: "this is the continuation of a multiline string begun
+                     elsewhere '"
+          }])
+      )
+    )
 
-    context 'when there is a multiline string with a defined ending', ->
-      lineScanner = new LineScanner "'this is a multiline string with a defined ending 'f := 5"
+    context('when there is a multiline string with a defined ending', ->
+      lineScanner = new LineScanner("'this is a multiline string with a defined
+                                     ending 'f := 5")
       lineScanner.extractStringLiterals()
-      
-      it 'toggles the current state of the multiline string of the scanner back to false', ->
+
+      it('toggles the current state of the multiline string of the scanner back
+          to false', ->
         expect(lineScanner.currentState.multiline.string).to.be.false
+      )
 
-      it 'increments the scanner position to just after the string', ->
-        expect(lineScanner.position).to.equal 51
+      it('increments the scanner position to just after the string', ->
+        expect(lineScanner.position).to.equal(51)
+      )
 
-      it 'adds the string literal to the line tokens', ->
+      it('adds the string literal to the line tokens', ->
         expect(lineScanner.lineTokens).to
-          .eql [{
+          .eql([{
               start: 0,
               kind: 'STRLIT',
               lexeme: "'this is a multiline string with a defined ending '"
-            }]
+            }])
+      )
+    )
+  )
 
-  describe '#extractWords', ->
-    
-    context 'when a reserved word is the next token', ->
-      lineScanner = new LineScanner "bool ="
+  describe('#extractWords', ->
+
+    context('when a reserved word is the next token', ->
+      lineScanner = new LineScanner('bool =')
       extractionResult = lineScanner.extractWords()
-      
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 4
-      
-      it 'adds the reserved word to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: 'bool', lexeme: 'bool', start: 0}]
 
-      it 'returns true since it was successful in extracting a word', ->
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(4)
+      )
+
+      it('adds the reserved word to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: 'bool',
+          lexeme: 'bool',
+          start: 0
+        }])
+      )
+
+      it('returns true since it(was successful in extracting a word', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when an identifer is the next token', ->
-      lineScanner = new LineScanner "myVariable := () ->"
+    context('when an identifer is the next token', ->
+      lineScanner = new LineScanner('myVariable := () ->')
       extractionResult = lineScanner.extractWords()
 
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 10
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(10)
+      )
 
-      it 'adds the identifer to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: 'ID', lexeme: 'myVariable', start: 0}]
+      it('adds the identifer to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: 'ID',
+          lexeme: 'myVariable',
+          start: 0
+        }])
+      )
 
-      it 'returns true since it was successful in extracting a word', ->
+      it('returns true since it(was successful in extracting a word', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when a word is not the next token', ->
-      lineScanner = new LineScanner "* 5"
+    context('when a word is not the next token', ->
+      lineScanner = new LineScanner('* 5')
       extractionResult = lineScanner.extractWords()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
 
-      it 'does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql []
+      it('does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([])
+      )
 
-      it 'returns false since it could not extract a word', ->
+      it('returns false since it(could not extract a word', ->
         expect(extractionResult).to.be.false
+      )
+    )
+  )
 
 
-  describe '#extractOneCharacterTokens', ->
+  describe('#extractOneCharacterTokens', ->
 
-    context 'when a one-character token is the next token', ->
-      lineScanner = new LineScanner "*5"
+    context('when a one-character token is the next token', ->
+      lineScanner = new LineScanner('*5')
       extractionResult = lineScanner.extractOneCharacterTokens()
 
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 1
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(1)
+      )
 
-      it 'adds the one-character token to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: '*', lexeme: '*', start: 0}]
+      it('adds the one-character token to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: '*',
+          lexeme: '*',
+          start: 0
+        }])
+      )
 
-      it 'returns true since a one-character token was successfully extracted', ->
+      it('returns true since a one-character token was successfully
+          extracted', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when a one-character token is not the next token', ->
-      lineScanner = new LineScanner " x"
+    context('when a one-character token is not the next token', ->
+      lineScanner = new LineScanner(' x')
       extractionResult = lineScanner.extractOneCharacterTokens()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
 
-      it 'does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql []
+      it('does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([])
+      )
 
-      it 'returns false since a one-character token was not extracted', ->
+      it('returns false since a one-character token was not extracted', ->
         expect(extractionResult).to.be.false
+      )
+    )
+  )
 
 
-  describe '#extractTwoCharacterTokens', ->
+  describe('#extractTwoCharacterTokens', ->
 
-    context 'when a two-character token is the next token', ->
-      lineScanner = new LineScanner "<="
+    context('when a two-character token is the next token', ->
+      lineScanner = new LineScanner('<=')
       extractionResult = lineScanner.extractTwoCharacterTokens()
 
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 2
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(2)
+      )
 
-      it 'adds the two-character token to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: '<=', lexeme: '<=', start: 0}]
+      it('adds the two-character token to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: '<=',
+          lexeme: '<=',
+          start: 0
+        }])
+      )
 
-      it 'returns true since a two-character token was successfully extracted', ->
+      it('returns true since a two-character token was successfully
+          extracted', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when a two-character token is not the next token', ->
-      lineScanner = new LineScanner "."
+    context('when a two-character token is not the next token', ->
+      lineScanner = new LineScanner('.')
       extractionResult = lineScanner.extractTwoCharacterTokens()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
 
-      it 'does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql []
+      it('does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([])
+      )
 
-      it 'returns false since a two-character token was not extracted', ->
+      it('returns false since a two-character token was not extracted', ->
         expect(extractionResult).to.be.false
+      )
+    )
+  )
 
-  describe '#extractNumericLiterals', ->
+  describe('#extractNumericLiterals', ->
 
-    context 'when a integer literal is the next token', ->
-      lineScanner = new LineScanner "23456"
+    context('when a integer literal is the next token', ->
+      lineScanner = new LineScanner('23456')
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 5
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(5)
+      )
 
-      it 'adds the integer literal to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: 'INTLIT', lexeme: '23456', start: 0}]
+      it('adds the integer literal to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: 'INTLIT',
+          lexeme: '23456',
+          start: 0
+        }])
+      )
 
-      it 'returns true since a numeric literal was extracted', ->
+      it('returns true since a numeric literal was extracted', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when a float literal is the next token', ->
-      lineScanner = new LineScanner "123.456"
+    context('when a float literal is the next token', ->
+      lineScanner = new LineScanner('123.456')
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it 'accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 7
+      it('accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(7)
+      )
 
-      it 'adds the integer literal to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql [{kind: 'FLOATLIT', lexeme: '123.456', start: 0}]
+      it('adds the integer literal to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([{
+          kind: 'FLOATLIT',
+          lexeme: '123.456',
+          start: 0
+        }])
+      )
 
-      it 'returns true since a numeric literal was extracted', ->
+      it('returns true since a numeric literal was extracted', ->
         expect(extractionResult).to.be.true
+      )
+    )
 
-    context 'when a numeric literal is not the next token', ->
-      lineScanner = new LineScanner "abc"
+    context('when a numeric literal is not the next token', ->
+      lineScanner = new LineScanner('abc')
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it 'does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal 0
+      it('does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal(0)
+      )
 
-      it 'does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql []
+      it('does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql([])
+      )
 
-      it 'returns false since no numeric literal was extracted', ->
+      it('returns false since no numeric literal was extracted', ->
         expect(extractionResult).to.be.false
+      )
+    )
+  )
+)

--- a/test/line_scanner_spec.coffee
+++ b/test/line_scanner_spec.coffee
@@ -1,20 +1,20 @@
-sinon = require('sinon')
-chai = require('chai')
-sinonChai = require('sinon-chai')
+sinon = require 'sinon'
+chai = require 'chai'
+sinonChai = require 'sinon-chai'
 expect = chai.expect
 chai.use(sinonChai)
-LineScanner = require('../tools/line_scanner')
+LineScanner = require '../tools/line_scanner'
 
 
-describe('LineScanner', ->
+describe 'LineScanner', ->
 
-  describe('#scan', ->
-    context('when the line has valid teascript tokens', ->
-      lineScanner = new LineScanner("f :=  -> 'hello' a.move() bool # comment")
+  describe '#scan', ->
+    context 'when the line has valid teascript tokens', ->
+      lineScanner = new LineScanner "f :=  -> 'hello' a.move() bool # comment"
       {lineTokens} = lineScanner.scan()
 
-      it('returns the appropriate tokens', ->
-        expect(lineTokens).to.eql([
+      it 'returns the appropriate tokens', ->
+        expect(lineTokens).to.eql [
           {kind: 'ID', lexeme: 'f', start: 0},
           {kind: ':=', lexeme: ':=', start: 2},
           {kind: '->', lexeme: '->', start: 6},
@@ -26,430 +26,347 @@ describe('LineScanner', ->
           {kind: ')', lexeme: ')', start: 24},
           {kind: 'bool', lexeme: 'bool', start: 26},
           {kind: 'newline', lexeme: 'newline', start: 27}
-        ])
-      )
-    )
+        ]
 
-    context('when the line is empty', ->
-      lineScanner = new LineScanner('')
+    context 'when the line is empty', ->
+      lineScanner = new LineScanner ''
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it('returns without trying to extract any tokens', ->
+      it 'returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
-      )
-    )
 
-    context('when the line is full of spaces', ->
-      lineScanner = new LineScanner('                    ')
+    context 'when the line is full of spaces', ->
+      lineScanner = new LineScanner '                    '
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it('returns without trying to extract any tokens', ->
+      it 'returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
-      )
-    )
 
-    context('when the line is commented out', ->
-      lineScanner = new LineScanner('# example commented out line')
+    context 'when the line is commented out', ->
+      lineScanner = new LineScanner '# example commented out line'
       lineScanner.extractTwoCharacterTokens = sinon.stub()
       lineScanner.extractOneCharacterTokens = sinon.stub()
       lineScanner.extractWords = sinon.stub()
       lineScanner.extractNumericLiterals = sinon.stub()
       lineScanner.scan()
 
-      it('returns without trying to extract any tokens', ->
+      it 'returns without trying to extract any tokens', ->
         expect(lineScanner.extractTwoCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractOneCharacterTokens).to.not.have.been.called
         expect(lineScanner.extractWords).to.not.have.been.called
         expect(lineScanner.extractNumericLiterals).to.not.have.been.called
-      )
-    )
-  )
 
-  describe('#skipSpaces', ->
 
-    context('when spaces are the next characters', ->
-      lineScanner = new LineScanner('        x := 5')
+
+
+  describe '#skipSpaces', ->
+
+    context 'when spaces are the next characters', ->
+      lineScanner = new LineScanner '        x := 5'
       lineScanner.skipSpaces()
 
-      it('increments the scanner position to the first non-space character', ->
-        expect(lineScanner.position).to.equal(8)
-      )
-    )
+      it 'increments the scanner position to the first non-space character', ->
+        expect(lineScanner.position).to.equal 8
 
-    context('when spaces are not the next characters', ->
-      lineScanner = new LineScanner('x := 5')
+    context 'when spaces are not the next characters', ->
+      lineScanner = new LineScanner 'x := 5'
       lineScanner.skipSpaces()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
-    )
-  )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
 
-  describe('#skipComments', ->
+  describe '#skipComments', ->
 
-    context('when there is a single line comment (single hash symbol)', ->
-      lineScanner = new LineScanner('# this is a single line comment ')
+    context 'when there is a single line comment (single hash symbol)', ->
+      lineScanner = new LineScanner '# this is a single line comment '
       lineScanner.skipComments()
 
-      it('increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal(32)
-      )
-    )
+      it 'increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal 32
 
-    context('when there is a multiline comment without a defined ending', ->
-      lineScanner = new LineScanner('## this is a multiline comment without a
-                                     defined ending')
+    context 'when there is a multiline comment without a defined ending', ->
+      lineScanner = new LineScanner '## this is a multiline comment without a
+                                     defined ending'
       lineScanner.skipComments()
 
-      it('sets the current state of the mulitline comment of the scanner to be
+      it 'sets the current state of the mulitline comment of the scanner to be
           true', ->
         expect(lineScanner.currentState.multiline.comment).to.be.true
-      )
 
-      it('increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal(55)
-      )
-    )
+      it 'increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal 55
 
-    context('when the scanner is in the middle of a multiline comment', ->
-      currentScannerState = {multiline: {comment: true}}
-      lineScanner = new LineScanner('this is the continuation of a multiline
-                                     comment begun elsewhere ##',
-                                    currentScannerState)
+    context 'when the scanner is in the middle of a multiline comment', ->
+      currentScannerState = multiline: comment: true
+      lineScanner = new LineScanner 'this is the continuation of a multiline
+                                     comment begun elsewhere ##'
+                                    , currentScannerState
       lineScanner.skipComments()
 
-      it('toggles the current state of the multiline comment of the scanner
-          back to false', ->
+      it 'toggles the current state of the multiline comment of the scanner back
+          to false', ->
         expect(lineScanner.currentState.multiline.comment).to.be.false
-      )
 
-      it('increments the scanner position to just after the comment', ->
-        expect(lineScanner.position).to.equal(66)
-      )
-    )
+      it 'increments the scanner position to just after the comment', ->
+        expect(lineScanner.position).to.equal 66
 
-    context('when there is a multiline comment with a defined ending', ->
-      lineScanner = new LineScanner('## this is a multiline comment with a
-                                     defined ending ## f := 5')
+    context 'when there is a multiline comment with a defined ending', ->
+      lineScanner = new LineScanner '## this is a multiline comment with a
+                                     defined ending ## f := 5'
       lineScanner.skipComments()
 
-      it('toggles the current state of the multiline comment of the scanner
-          back to false', ->
+      it 'toggles the current state of the multiline comment of the scanner back
+          to false', ->
         expect(lineScanner.currentState.multiline.comment).to.be.false
-      )
 
-      it('increments the scanner position to just after the comment', ->
-        expect(lineScanner.position).to.equal(55)
-      )
-    )
+      it 'increments the scanner position to just after the comment', ->
+        expect(lineScanner.position).to.equal 55
 
 
-    context('when a line does not being with a hash symbol (#)', ->
-      lineScanner = new LineScanner('x := 5')
+    context 'when a line does not being with a hash symbol (#)', ->
+      lineScanner = new LineScanner 'x := 5'
       lineScanner.skipComments()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
-    )
-  )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
-  describe('#extractStringLiterals', ->
+  describe '#extractStringLiterals', ->
 
-    context('when the next token is a string without a defined ending', ->
-      lineScanner = new LineScanner("'this is a multiline string without a
-                                     defined ending")
+    context 'when the next token is a string without a defined ending', ->
+      lineScanner = new LineScanner "'this is a multiline string without a
+                                     defined ending"
       lineScanner.extractStringLiterals()
 
-      it('sets the current state of the mulitline string of the scanner to be
+      it 'sets the current state of the mulitline string of the scanner to be
           true', ->
         expect(lineScanner.currentState.multiline.string).to.be.true
-      )
 
-      it('increments the scanner position to the end of the line', ->
-        expect(lineScanner.position).to.equal(52)
-      )
+      it 'increments the scanner position to the end of the line', ->
+        expect(lineScanner.position).to.equal 52
 
-      it('does not add any tokens yet to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([])
-      )
-    )
+      it 'does not add any tokens yet to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql []
 
-    context('when the scanner is in the middle of a multiline string', ->
-      currentScannerState = { multiline: { string: true }}
-      lineScanner = new LineScanner("this is the continuation of a multiline
-                                     string begun elsewhere '",
-                                    currentScannerState)
+    context 'when the scanner is in the middle of a multiline string', ->
+      currentScannerState = multiline: string: true
+      lineScanner = new LineScanner "this is the continuation of a multiline
+                                     string begun elsewhere '"
+                                    , currentScannerState
       lineScanner.extractStringLiterals()
 
-      it('toggles the current state of the multiline string of the scanner back
+      it 'toggles the current state of the multiline string of the scanner back
           to false', ->
         expect(lineScanner.currentState.multiline.string).to.be.false
-      )
 
-      it('increments the scanner position to the end of the string', ->
-        expect(lineScanner.position).to.equal(64)
-      )
+      it 'increments the scanner position to the end of the string', ->
+        expect(lineScanner.position).to.equal 64
 
-      it('adds the string token to the line tokens', ->
+      it 'adds the string token to the line tokens', ->
         expect(lineScanner.lineTokens).to
-          .eql([{
+          .eql [{
             start: 0,
             kind: 'STRLIT',
             lexeme: "this is the continuation of a multiline string begun
                      elsewhere '"
-          }])
-      )
-    )
+          }]
 
-    context('when there is a multiline string with a defined ending', ->
-      lineScanner = new LineScanner("'this is a multiline string with a defined
-                                     ending 'f := 5")
+    context 'when there is a multiline string with a defined ending', ->
+      lineScanner = new LineScanner "'this is a multiline string with a defined
+                                     ending 'f := 5"
       lineScanner.extractStringLiterals()
 
-      it('toggles the current state of the multiline string of the scanner back
+      it 'toggles the current state of the multiline string of the scanner back
           to false', ->
         expect(lineScanner.currentState.multiline.string).to.be.false
-      )
 
-      it('increments the scanner position to just after the string', ->
-        expect(lineScanner.position).to.equal(51)
-      )
+      it 'increments the scanner position to just after the string', ->
+        expect(lineScanner.position).to.equal 51
 
-      it('adds the string literal to the line tokens', ->
+      it 'adds the string literal to the line tokens', ->
         expect(lineScanner.lineTokens).to
-          .eql([{
+          .eql [{
               start: 0,
               kind: 'STRLIT',
               lexeme: "'this is a multiline string with a defined ending '"
-            }])
-      )
-    )
-  )
+            }]
 
-  describe('#extractWords', ->
+  describe '#extractWords', ->
 
-    context('when a reserved word is the next token', ->
-      lineScanner = new LineScanner('bool =')
+    context 'when a reserved word is the next token', ->
+      lineScanner = new LineScanner 'bool ='
       extractionResult = lineScanner.extractWords()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(4)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 4
 
-      it('adds the reserved word to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the reserved word to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: 'bool',
           lexeme: 'bool',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since it(was successful in extracting a word', ->
+      it 'returns true since it was successful in extracting a word', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when an identifer is the next token', ->
-      lineScanner = new LineScanner('myVariable := () ->')
+    context 'when an identifer is the next token', ->
+      lineScanner = new LineScanner 'myVariable := () ->'
       extractionResult = lineScanner.extractWords()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(10)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 10
 
-      it('adds the identifer to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the identifer to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: 'ID',
           lexeme: 'myVariable',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since it(was successful in extracting a word', ->
+      it 'returns true since it was successful in extracting a word', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when a word is not the next token', ->
-      lineScanner = new LineScanner('* 5')
+    context 'when a word is not the next token', ->
+      lineScanner = new LineScanner '* 5'
       extractionResult = lineScanner.extractWords()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
-      it('does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([])
-      )
+      it 'does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql []
 
-      it('returns false since it(could not extract a word', ->
+      it 'returns false since it could not extract a word', ->
         expect(extractionResult).to.be.false
-      )
-    )
-  )
 
 
-  describe('#extractOneCharacterTokens', ->
+  describe '#extractOneCharacterTokens', ->
 
-    context('when a one-character token is the next token', ->
-      lineScanner = new LineScanner('*5')
+    context 'when a one-character token is the next token', ->
+      lineScanner = new LineScanner '*5'
       extractionResult = lineScanner.extractOneCharacterTokens()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(1)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 1
 
-      it('adds the one-character token to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the one-character token to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: '*',
           lexeme: '*',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since a one-character token was successfully
+      it 'returns true since a one-character token was successfully
           extracted', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when a one-character token is not the next token', ->
-      lineScanner = new LineScanner(' x')
+    context 'when a one-character token is not the next token', ->
+      lineScanner = new LineScanner ' x'
       extractionResult = lineScanner.extractOneCharacterTokens()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
-      it('does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([])
-      )
+      it 'does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql []
 
-      it('returns false since a one-character token was not extracted', ->
+      it 'returns false since a one-character token was not extracted', ->
         expect(extractionResult).to.be.false
-      )
-    )
-  )
 
 
-  describe('#extractTwoCharacterTokens', ->
+  describe '#extractTwoCharacterTokens', ->
 
-    context('when a two-character token is the next token', ->
-      lineScanner = new LineScanner('<=')
+    context 'when a two-character token is the next token', ->
+      lineScanner = new LineScanner '<='
       extractionResult = lineScanner.extractTwoCharacterTokens()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(2)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 2
 
-      it('adds the two-character token to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the two-character token to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: '<=',
           lexeme: '<=',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since a two-character token was successfully
+      it 'returns true since a two-character token was successfully
           extracted', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when a two-character token is not the next token', ->
-      lineScanner = new LineScanner('.')
+    context 'when a two-character token is not the next token', ->
+      lineScanner = new LineScanner '.'
       extractionResult = lineScanner.extractTwoCharacterTokens()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
-      it('does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([])
-      )
+      it 'does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql []
 
-      it('returns false since a two-character token was not extracted', ->
+      it 'returns false since a two-character token was not extracted', ->
         expect(extractionResult).to.be.false
-      )
-    )
-  )
 
-  describe('#extractNumericLiterals', ->
+  describe '#extractNumericLiterals', ->
 
-    context('when a integer literal is the next token', ->
-      lineScanner = new LineScanner('23456')
+    context 'when a integer literal is the next token', ->
+      lineScanner = new LineScanner '23456'
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(5)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 5
 
-      it('adds the integer literal to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the integer literal to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: 'INTLIT',
           lexeme: '23456',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since a numeric literal was extracted', ->
+      it 'returns true since a numeric literal was extracted', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when a float literal is the next token', ->
-      lineScanner = new LineScanner('123.456')
+    context 'when a float literal is the next token', ->
+      lineScanner = new LineScanner '123.456'
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it('accurately increments the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(7)
-      )
+      it 'accurately increments the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 7
 
-      it('adds the integer literal to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([{
+      it 'adds the integer literal to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql [{
           kind: 'FLOATLIT',
           lexeme: '123.456',
           start: 0
-        }])
-      )
+        }]
 
-      it('returns true since a numeric literal was extracted', ->
+      it 'returns true since a numeric literal was extracted', ->
         expect(extractionResult).to.be.true
-      )
-    )
 
-    context('when a numeric literal is not the next token', ->
-      lineScanner = new LineScanner('abc')
+    context 'when a numeric literal is not the next token', ->
+      lineScanner = new LineScanner 'abc'
       extractionResult = lineScanner.extractNumericLiterals()
 
-      it('does not increment the current position of the scanner', ->
-        expect(lineScanner.position).to.equal(0)
-      )
+      it 'does not increment the current position of the scanner', ->
+        expect(lineScanner.position).to.equal 0
 
-      it('does not add anything to the line tokens', ->
-        expect(lineScanner.lineTokens).to.eql([])
-      )
+      it 'does not add anything to the line tokens', ->
+        expect(lineScanner.lineTokens).to.eql []
 
-      it('returns false since no numeric literal was extracted', ->
+      it 'returns false since no numeric literal was extracted', ->
         expect(extractionResult).to.be.false
-      )
-    )
-  )
-)

--- a/tools/line_scanner.coffee
+++ b/tools/line_scanner.coffee
@@ -1,4 +1,4 @@
-tokens = require './tokens'
+tokens = require('./tokens')
 
 class LineScanner
   constructor: (@line, @currentState) ->
@@ -28,29 +28,29 @@ class LineScanner
       continue if @extractWords()
       continue if @extractNumericLiterals()
 
-      # return an error if we were not able to 
+      # return an error if we were not able to
       # extract any tokens from the line
-      return {errors: "invalid token bro"}
+      return({errors: 'invalid token bro'})
     
     # add newline token after each line
-    @addToken {kind: 'newline'}
+    @addToken({kind: 'newline'})
     return {@lineTokens, @currentState}
 
   addToken: ({kind, lexeme}) ->
     lexeme ?= kind
-    @lineTokens.push {lexeme, kind, @start}
+    @lineTokens.push({lexeme, kind, @start})
 
   skipSpaces: ->
-    @position++ and @start++ while /\s/.test @line[@position]
+    @position++ and @start++ while /\s/.test(@line[@position])
 
   skipComments: ->
     if @currentState.multiline.comment
       @skipMultilineComment()
     else if @line[@position] is '#'
-      if @line[@position+1] is '#'
+      if @line[@position + 1] is '#'
         @position += 2
         @currentState.multiline.comment = true
-        @skipMultilineComment() 
+        @skipMultilineComment()
       else
         # skip rest of line for single line comment
         @position = @line.length
@@ -61,14 +61,14 @@ class LineScanner
     return unless @position < @line.length
 
     # found trailing two hash symbols for end of multiline comment
-    if @line[@position...@position+2] is '##'
+    if @line[@position...@position + 2] is '##'
       @currentState.multiline.comment = false
       @position += 2
 
   extractTwoCharacterTokens: ->
     @start = @position
-    if @line[@position...@position+2] in tokens.twoCharacterTokens
-      @addToken {kind: @line[@position...@position+2]}
+    if @line[@position...@position + 2] in tokens.twoCharacterTokens
+      @addToken({kind: @line[@position...@position + 2]})
       @position += 2
       return true
     return false
@@ -76,7 +76,7 @@ class LineScanner
   extractOneCharacterTokens: ->
     @start = @position
     if @line[@position] in tokens.oneCharacterTokens
-      @addToken {kind: @line[@position]}
+      @addToken({kind: @line[@position]})
       @position++
       return true
     return false
@@ -96,19 +96,20 @@ class LineScanner
 
   extractMultilineString: ->
     # search for trailing quote for end of multiline string
-    @position++ while @line[@position] isnt ("'" or '"') and @position < @line.length
+    @position++ while @line[@position] isnt ("'" or '"') and
+                      @position < @line.length
     return unless @position < @line.length
 
     # found trailing quote for end of multiline string (isn't an escaped quote)
     # TODO: implement ability to escape quote characters?
-    if @line[@position] is ("'" or '"') and @line[@position-1]
+    if @line[@position] is ("'" or '"') and @line[@position - 1]
       @currentState.multiline.string = false
       @position++
-      @addToken {kind: 'STRLIT', lexeme: @line[@start...@position]}
+      @addToken({kind: 'STRLIT', lexeme: @line[@start...@position]})
 
   extractWords: ->
     @start = @position
-    if /[a-zA-Z]/.test @line[@position]
+    if /[a-zA-Z]/.test(@line[@position])
       @position++ while /\w/.test(@line[@position]) and @position < @line.length
       @addWord(word = @line[@start...@position])
       return true
@@ -116,21 +117,21 @@ class LineScanner
 
   addWord: (word) ->
     if word in tokens.reservedWords
-      @addToken {kind: word}
+      @addToken({kind: word})
     else
-      @addToken {kind: 'ID', lexeme: word}
+      @addToken({kind: 'ID', lexeme: word})
 
   extractNumericLiterals: ->
     @start = @position
-    if /\d/.test @line[@position]
+    if /\d/.test(@line[@position])
       @extractNumberSequence()
       if @line[@position] is '.'
         @position++
         # get numbers after the decimal point
         @extractNumberSequence()
-        @addToken {kind: 'FLOATLIT', lexeme: @line[@start...@position]}
+        @addToken({kind: 'FLOATLIT', lexeme: @line[@start...@position]})
       else
-        @addToken {kind: 'INTLIT', lexeme: @line[@start...@position]}
+        @addToken({kind: 'INTLIT', lexeme: @line[@start...@position]})
       return true
     return false
 

--- a/tools/line_scanner.coffee
+++ b/tools/line_scanner.coffee
@@ -1,4 +1,4 @@
-tokens = require('./tokens')
+tokens = require './tokens'
 
 class LineScanner
   constructor: (@line, @currentState) ->
@@ -30,18 +30,18 @@ class LineScanner
 
       # return an error if we were not able to
       # extract any tokens from the line
-      return({errors: 'invalid token bro'})
+      return {errors: 'invalid token bro'}
     
     # add newline token after each line
-    @addToken({kind: 'newline'})
+    @addToken {kind: 'newline'}
     return {@lineTokens, @currentState}
 
   addToken: ({kind, lexeme}) ->
     lexeme ?= kind
-    @lineTokens.push({lexeme, kind, @start})
+    @lineTokens.push {lexeme, kind, @start}
 
   skipSpaces: ->
-    @position++ and @start++ while /\s/.test(@line[@position])
+    @position++ and @start++ while /\s/.test @line[@position]
 
   skipComments: ->
     if @currentState.multiline.comment
@@ -68,7 +68,7 @@ class LineScanner
   extractTwoCharacterTokens: ->
     @start = @position
     if @line[@position...@position + 2] in tokens.twoCharacterTokens
-      @addToken({kind: @line[@position...@position + 2]})
+      @addToken {kind: @line[@position...@position + 2]}
       @position += 2
       return true
     return false
@@ -76,7 +76,7 @@ class LineScanner
   extractOneCharacterTokens: ->
     @start = @position
     if @line[@position] in tokens.oneCharacterTokens
-      @addToken({kind: @line[@position]})
+      @addToken {kind: @line[@position]}
       @position++
       return true
     return false
@@ -105,11 +105,11 @@ class LineScanner
     if @line[@position] is ("'" or '"') and @line[@position - 1]
       @currentState.multiline.string = false
       @position++
-      @addToken({kind: 'STRLIT', lexeme: @line[@start...@position]})
+      @addToken {kind: 'STRLIT', lexeme: @line[@start...@position]}
 
   extractWords: ->
     @start = @position
-    if /[a-zA-Z]/.test(@line[@position])
+    if /[a-zA-Z]/.test @line[@position]
       @position++ while /\w/.test(@line[@position]) and @position < @line.length
       @addWord(word = @line[@start...@position])
       return true
@@ -117,21 +117,21 @@ class LineScanner
 
   addWord: (word) ->
     if word in tokens.reservedWords
-      @addToken({kind: word})
+      @addToken {kind: word}
     else
-      @addToken({kind: 'ID', lexeme: word})
+      @addToken {kind: 'ID', lexeme: word}
 
   extractNumericLiterals: ->
     @start = @position
-    if /\d/.test(@line[@position])
+    if /\d/.test @line[@position]
       @extractNumberSequence()
       if @line[@position] is '.'
         @position++
         # get numbers after the decimal point
         @extractNumberSequence()
-        @addToken({kind: 'FLOATLIT', lexeme: @line[@start...@position]})
+        @addToken {kind: 'FLOATLIT', lexeme: @line[@start...@position]}
       else
-        @addToken({kind: 'INTLIT', lexeme: @line[@start...@position]})
+        @addToken {kind: 'INTLIT', lexeme: @line[@start...@position]}
       return true
     return false
 

--- a/tools/tokens.coffee
+++ b/tools/tokens.coffee
@@ -1,7 +1,8 @@
 class Tokens
   
   @oneCharacterTokens = [
-    '+', '-', '*', '/',                  # arithmetic operators
+    '^', '&', '|',                       # bitwise operators
+    '+', '-', '*', '/', '%',             # arithmetic operators
     '(', ')',                            # for tuple construction
     '[', ']',                            # for list construction
     '<', '>',                            # for set construction
@@ -11,6 +12,7 @@ class Tokens
   ]
 
   @twoCharacterTokens = [
+    '+=', '-=', '*=', '/=', '++', '--',  # mutators
     '<=', '>=',                          # relational operators
     ':=',                                # assignment
     '->'                                 # function
@@ -20,10 +22,12 @@ class Tokens
     'int', 'double', 'bool', 'none',     # primitive types
     'class', 'trait',                    # reference types
     'for', 'in', 'by', 'while', 'end',   # loops/blocks/range keywords
-    'and', 'or', 'is',                   # relational operators
+    'and', 'or', 'is',                   # logical operators
+    'if', 'else',                        # if/then
     'not',                               # negation
     'true', 'false',                     # boolean literals
-    'new'                                # instantiate a class/create an object
+    'new',                               # instantiate a class/create an object
+    'return'                             # we need to return from functions
   ]
 
 module.exports = Tokens


### PR DESCRIPTION
I think we ought to have a clean, consistent code style. I've attached my idea of what our [coffeelint.json](http://www.coffeelint.org/) should look like, but I'm open to suggestions. 

I also took the liberty of fixing all the files so they comply with the current coffeelint.json and added linting to travis, so builds will fail if they're not properly linted. 

To use coffeelint, you can do `npm install -g coffeelint` and install editor plugins like [SublimeLinter-coffeelint](https://packagecontrol.io/packages/SublimeLinter-coffeelint). Follow the instructions on the page. 

Similar plugins exist for vim, emacs, and Atom. It should automagically pick up our coffeelint.json and provide hints within the editor as to where your code isn't compliant.
